### PR TITLE
Flow 6.* compatibility

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -20,7 +20,7 @@ use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Error\WithReferenceCodeInterface;
 use Neos\Flow\Exception;
 use Neos\Flow\Log\PsrSystemLoggerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Utility\Environment;
 use Sentry\Options;
@@ -63,7 +63,7 @@ class SentryClient
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 


### PR DESCRIPTION
This change makes flownative/sentry compatible to Flow 6.0 - 6.2