### PR TITLE
Improve stacktraces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ reporting of errors to [Sentry](https://www.sentry.io)
 
 ## Key Features
 
+This package makes sure that exceptions and errors logged by the Flow 
+framework also end up in Sentry. This client takes some extra care to
+clean up paths and filenames of stacktraces so you get good overview
+while looking at an issue in the Sentry UI.
 
 ## Installation
 


### PR DESCRIPTION
This change improves stacktraces by cleaning up paths and filenames of proxy classes. Additionally, classes located in the Framework directory are declared as not being part of the app and can be filtered in the Sentry UI.

Resolves #12