### PR TITLE
Some code cleanup

### DIFF
--- a/Classes/Exception/ProductionExceptionHandler.php
+++ b/Classes/Exception/ProductionExceptionHandler.php
@@ -49,13 +49,11 @@ class ProductionExceptionHandler extends \Neos\Flow\Error\ProductionExceptionHan
         } catch (\Throwable $e) {
         }
 
-        switch (PHP_SAPI) {
-            case 'cli':
-                # Doesn't return:
-                $this->echoExceptionCli($exception, $exceptionWasLogged);
-            break;
-            default:
-                $this->echoExceptionWeb($exception);
+        if (PHP_SAPI === 'cli') {
+            # Doesn't return:
+            $this->echoExceptionCli($exception, $exceptionWasLogged);
+        } else {
+            $this->echoExceptionWeb($exception);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "MIT"
     ],
     "require": {
-        "php": "7.4.* || 8.0.* || 8.1.*",
-        "neos/flow": "^5.0 || ^6.0 || ^7.0 || @dev",
+        "php": "^7.4 || ^8.0",
+        "neos/flow": "^6.3 || ^7.0 || ^8.0 || @dev",
         "sentry/sdk": "^3.0",
         "jenssegers/agent": "^2.6"
     },
@@ -23,6 +23,5 @@
         "psr-4": {
             "Flownative\\Sentry\\": "Classes"
         }
-    },
-    "extra": {}
+    }
 }


### PR DESCRIPTION
- align `ProductionExceptionHandler` with `DebugExceptionHandler`
- clean up class property declarations
- use `PHP_SAPI` instead of `php_sapi_name()`
- streamline regular expressions
- merge `str_replace()` calls
- drop support for Flow < 6.3
- allow use with Flow ^8.0