### PR TITLE
Provide more information on args in traces

### DIFF
--- a/Classes/Command/SentryCommandController.php
+++ b/Classes/Command/SentryCommandController.php
@@ -13,8 +13,11 @@ namespace Flownative\Sentry\Command;
  * source code.
  */
 
-use Flownative\Sentry\Exception\SentryClientTestException;
 use Flownative\Sentry\SentryClient;
+use Flownative\Sentry\Test\JsonSerializableTestArgument;
+use Flownative\Sentry\Test\SentryClientTestException;
+use Flownative\Sentry\Test\StringableTestArgument;
+use Flownative\Sentry\Test\ThrowingClass;
 use Neos\Flow\Annotations\Inject;
 use Neos\Flow\Cli\CommandController;
 use Sentry\Severity;
@@ -34,6 +37,8 @@ final class SentryCommandController extends CommandController
      * configuration, credentials and connection to the Sentry server work fine.
      *
      * For testing purposes, an event will be sent to Sentry.
+     *
+     * @throws SentryClientTestException
      */
     public function testCommand(): void
     {
@@ -66,16 +71,6 @@ final class SentryCommandController extends CommandController
         $this->outputLine('This command will now throw an exception for testing purposes.');
         $this->outputLine();
 
-        $this->throwException('Some argument');
-    }
-
-    /**
-     * @param string $someArgument
-     * @throws SentryClientTestException
-     */
-    protected function throwException(string $someArgument): void
-    {
-        $previousException = new \RuntimeException('Test "previous" exception thrown by the SentryCommandController', 1614759554);
-        throw new SentryClientTestException('Test exception in SentryCommandController', 1614759519, $previousException);
+        (new ThrowingClass())->throwException(new StringableTestArgument((string)M_PI));
     }
 }

--- a/Classes/RepresentationSerializer.php
+++ b/Classes/RepresentationSerializer.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\Sentry;
+
+/*
+ * This file is part of the Flownative.Sentry package.
+ *
+ * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Serializes a value into a representation that should reasonably suggest
+ * both the type and value, and be serializable into JSON.
+ *
+ * It kicks in if the parent's serializeObject() return an empty array, i.e.
+ * no useful information could be extracted from simply iterating over the
+ * object's properties…
+ *
+ * First is tries to use __toString(), then json_serialize(), if those are
+ * supported.
+ */
+class RepresentationSerializer extends \Sentry\Serializer\RepresentationSerializer
+{
+    protected function serializeObject($object, int $_depth = 0, array $hashes = [])
+    {
+        $serializedObject = parent::serializeObject($object, $_depth, $hashes);
+        if ($serializedObject === []) {
+            if ($object instanceof \Stringable || is_callable([$object, '__toString'])) {
+                $serializedObject = [
+                    'type' => get_class($object),
+                    'value (as string)' => (string)$object
+                ];
+            } elseif ($object instanceof \JsonSerializable) {
+                try {
+                    $serializedObject = [
+                        'type' => get_class($object),
+                        'value (as JSON)' => json_encode($object, JSON_THROW_ON_ERROR)
+                    ];
+                } catch (\JsonException $e) {
+                    $serializedObject = 'Object ' . get_class($object);
+                }
+            }
+
+            return $serializedObject;
+        }
+    }
+}

--- a/Classes/RepresentationSerializer.php
+++ b/Classes/RepresentationSerializer.php
@@ -47,28 +47,27 @@ class RepresentationSerializer extends \Sentry\Serializer\RepresentationSerializ
         $classSerializers = $this->getClassSerializers();
         foreach ($classSerializers as $targetType => $classSerializer) {
             if ($object instanceof $targetType) {
-                return [
-                    'class' => get_class($object),
-                    'data' => $this->serializeRecursively($classSerializer($object), $_depth + 1),
-                ];
+                $serializedObject = $this->serializeRecursively($classSerializer($object), $_depth + 1);
+                $serializedObject['__class'] = get_class($object);
+                return $serializedObject;
             }
         }
 
         if ($object instanceof \Stringable || is_callable([$object, '__toString'])) {
             $serializedObject = [
-                'class' => get_class($object),
-                'data' => (string)$object
+                '__class' => get_class($object),
+                '__string' => (string)$object
             ];
         } elseif ($object instanceof \JsonSerializable) {
             try {
                 $serializedObject = [
-                    'class' => get_class($object),
-                    'data' => json_encode($object, JSON_THROW_ON_ERROR)
+                    '__class' => get_class($object),
+                    '__json' => json_encode($object, JSON_THROW_ON_ERROR)
                 ];
             } catch (\JsonException $e) {
                 $serializedObject = [
-                    'class' => get_class($object),
-                    'serialization error' => $e->getMessage()
+                    '__class' => get_class($object),
+                    '__serialization_error' => $e->getMessage()
                 ];
             }
         } else {
@@ -83,10 +82,8 @@ class RepresentationSerializer extends \Sentry\Serializer\RepresentationSerializ
                 }
             }
 
-            $serializedObject = [
-                'class ' => get_class($object),
-                'data' => $data
-            ];
+            $serializedObject = $data;
+            $serializedObject['__class '] = get_class($object);
         }
 
         return $serializedObject;

--- a/Classes/RepresentationSerializer.php
+++ b/Classes/RepresentationSerializer.php
@@ -32,14 +32,14 @@ class RepresentationSerializer extends \Sentry\Serializer\RepresentationSerializ
         if ($serializedObject === []) {
             if ($object instanceof \Stringable || is_callable([$object, '__toString'])) {
                 $serializedObject = [
-                    'type' => get_class($object),
-                    'value (as string)' => (string)$object
+                    'Object' => get_class($object),
+                    '(as string)' => (string)$object
                 ];
             } elseif ($object instanceof \JsonSerializable) {
                 try {
                     $serializedObject = [
-                        'type' => get_class($object),
-                        'value (as JSON)' => json_encode($object, JSON_THROW_ON_ERROR)
+                        'Object' => get_class($object),
+                        '(as JSON)' => json_encode($object, JSON_THROW_ON_ERROR)
                     ];
                 } catch (\JsonException $e) {
                     $serializedObject = 'Object ' . get_class($object);

--- a/Classes/RepresentationSerializer.php
+++ b/Classes/RepresentationSerializer.php
@@ -6,7 +6,7 @@ namespace Flownative\Sentry;
 /*
  * This file is part of the Flownative.Sentry package.
  *
- * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ * (c) Robert Lemke, Flownative GmbH - www.flownative.com
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this

--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -37,7 +37,6 @@ use Sentry\ExceptionMechanism;
 use Sentry\Frame;
 use Sentry\Options;
 use Sentry\SentrySdk;
-use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Severity;
 use Sentry\Stacktrace;
 use Sentry\StacktraceBuilder;
@@ -89,11 +88,13 @@ class SentryClient
 
     public function initializeObject(): void
     {
+        $representationSerializer = new RepresentationSerializer(
+            new Options([])
+        );
+        $representationSerializer->setSerializeAllObjects(true);
         $this->stacktraceBuilder = new StacktraceBuilder(
             new Options([]),
-            new RepresentationSerializer(
-                new Options([])
-            )
+            $representationSerializer
         );
 
         if (empty($this->dsn)) {
@@ -339,6 +340,5 @@ class SentryClient
         } while ($throwable = $throwable->getPrevious());
 
         $event->setExceptions($exceptions);
-
     }
 }

--- a/Classes/Test/JsonSerializableTestArgument.php
+++ b/Classes/Test/JsonSerializableTestArgument.php
@@ -6,7 +6,7 @@ namespace Flownative\Sentry\Test;
 /*
  * This file is part of the Flownative.Sentry package.
  *
- * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ * (c) Robert Lemke, Flownative GmbH - www.flownative.com
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this

--- a/Classes/Test/JsonSerializableTestArgument.php
+++ b/Classes/Test/JsonSerializableTestArgument.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\Sentry\Test;
+
+/*
+ * This file is part of the Flownative.Sentry package.
+ *
+ * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class JsonSerializableTestArgument implements \JsonSerializable
+{
+    private int $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/Classes/Test/SentryClientTestException.php
+++ b/Classes/Test/SentryClientTestException.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Flownative\Sentry\Exception;
+namespace Flownative\Sentry\Test;
 
 /*
  * This file is part of the Flownative.Sentry package.

--- a/Classes/Test/StringableTestArgument.php
+++ b/Classes/Test/StringableTestArgument.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\Sentry\Test;
+
+/*
+ * This file is part of the Flownative.Sentry package.
+ *
+ * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class StringableTestArgument
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/Classes/Test/StringableTestArgument.php
+++ b/Classes/Test/StringableTestArgument.php
@@ -6,7 +6,7 @@ namespace Flownative\Sentry\Test;
 /*
  * This file is part of the Flownative.Sentry package.
  *
- * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ * (c) Robert Lemke, Flownative GmbH - www.flownative.com
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this

--- a/Classes/Test/ThrowingClass.php
+++ b/Classes/Test/ThrowingClass.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\Sentry\Test;
+
+/*
+ * This file is part of the Flownative.Sentry package.
+ *
+ * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class ThrowingClass
+{
+    /**
+     * @throws SentryClientTestException
+     */
+    public function throwException(StringableTestArgument $argument): void
+    {
+        $this->doNotThrowYet((float)(string)$argument);
+    }
+
+    /**
+     * @throws SentryClientTestException
+     */
+    private function doNotThrowYet(float $argument): void
+    {
+        $anotherArgument = new JsonSerializableTestArgument((int)$argument);
+        $this->doreallyThrowException($anotherArgument);
+    }
+
+    /**
+     * @throws SentryClientTestException
+     */
+    private function doreallyThrowException(JsonSerializableTestArgument $argument): void
+    {
+        $previousException = new \RuntimeException('Test "previous" exception in ThrowingClass', 1662712735);
+        throw new SentryClientTestException('Test exception in ThrowingClass', 1662712736, $previousException);
+    }
+}

--- a/Classes/Test/ThrowingClass.php
+++ b/Classes/Test/ThrowingClass.php
@@ -6,7 +6,7 @@ namespace Flownative\Sentry\Test;
 /*
  * This file is part of the Flownative.Sentry package.
  *
- * (c) Karsten Dambekalns, Flownative GmbH - www.flownative.com
+ * (c) Robert Lemke, Flownative GmbH - www.flownative.com
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "MIT"
     ],
     "require": {
+        "ext-json": "*",
         "php": "^7.4 || ^8.0",
         "neos/flow": "^6.3 || ^7.0 || ^8.0 || @dev",
         "sentry/sdk": "^3.0",


### PR DESCRIPTION
This provides a better representation of function arguments in traces that are objects. So far only the type of the object was visible, now a string or JSON representation is shown, if possible.