### PR TITLE
Let exceptions provide additional data

### DIFF
--- a/Classes/Context/WithExtraDataInterface.php
+++ b/Classes/Context/WithExtraDataInterface.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\Sentry\Context;
+
+/*
+ * This file is part of the Flownative.Sentry package.
+ *
+ * (c) Robert Lemke, Flownative GmbH - www.flownative.com
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+interface WithExtraDataInterface
+{
+    /**
+     * Returns an array with extra data to communicate to Sentry when capturing an exception.
+     *
+     * This is supposed to be implemented by a user-defined exception.
+     */
+    public function getExtraData(): array;
+}

--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -15,6 +15,7 @@ namespace Flownative\Sentry;
 
 use Flownative\Sentry\Context\UserContext;
 use Flownative\Sentry\Context\UserContextServiceInterface;
+use Flownative\Sentry\Context\WithExtraDataInterface;
 use GuzzleHttp\Psr7\ServerRequest;
 use Jenssegers\Agent\Agent;
 use Neos\Flow\Annotations as Flow;
@@ -27,6 +28,7 @@ use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Session\Session;
 use Neos\Flow\Session\SessionManagerInterface;
 use Neos\Flow\Utility\Environment;
+use Neos\Utility\Arrays;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Sentry\Event;
@@ -186,6 +188,10 @@ class SentryClient
         if ($throwable instanceof WithReferenceCodeInterface) {
             $extraData['Reference Code'] = $throwable->getReferenceCode();
         }
+        if ($throwable instanceof WithExtraDataInterface) {
+            $extraData = Arrays::arrayMergeRecursiveOverrule($extraData, $throwable->getExtraData());
+        }
+
         $extraData['PHP Process Inode'] = getmyinode();
         $extraData['PHP Process PID'] = getmypid();
         $extraData['PHP Process UID'] = getmyuid();

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ similar to the following message:
 … NOTICE Exception 12345: The exception message (Ref: 202004161706040c28ae | Sentry: ignored)
 ```
 
+## Additional Data
+
+Exceptions declared in an application can optionally implement 
+`WithAdditionalDataInterface` provided by this package. If they do, the 
+array returned by `getAdditionalData()` will be visible in the "additional 
+data" section in Sentry.
+
+Note that the array must only contain values of simple types, such as 
+strings, booleans or integers.
+
 ## Testing the Client
 
 This package provides a command controller which allows you to log a


### PR DESCRIPTION
Exceptions declared in an application can optionally implement `WithAdditionalDataInterface` provided by this package. If they do, the array returned by `getAdditionalData()` will be visible in the "additional data" section in Sentry.

The array must only contain values of simple types, such as strings, booleans or integers.