### PR TITLE
feat(config): make sample rate configurable in SentryClient

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -53,6 +53,7 @@ class SentryClient
     protected string $dsn;
     protected string $environment;
     protected string $release;
+    protected string $sampleRate;
     protected array $excludeExceptionTypes = [];
     protected StacktraceBuilder $stacktraceBuilder;
 
@@ -85,6 +86,7 @@ class SentryClient
         $this->dsn = $settings['dsn'] ?? '';
         $this->environment = $settings['environment'] ?? '';
         $this->release = $settings['release'] ?? '';
+        $this->sampleRate = $settings['sampleRate'] ?? 1;
         $this->excludeExceptionTypes = $settings['capture']['excludeExceptionTypes'] ?? [];
     }
 
@@ -107,7 +109,7 @@ class SentryClient
             'dsn' => $this->dsn,
             'environment' => $this->environment,
             'release' => $this->release,
-            'sample_rate' => 1,
+            'sample_rate' => (float)$this->sampleRate,
             'in_app_exclude' => [
                 FLOW_PATH_ROOT . '/Packages/Application/Flownative.Sentry/Classes/',
                 FLOW_PATH_ROOT . '/Packages/Framework/Neos.Flow/Classes/Aop/',

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,6 +3,7 @@ Flownative:
     dsn: "%env:SENTRY_DSN%"
     environment: "%env:SENTRY_ENVIRONMENT%"
     release: "%env:SENTRY_RELEASE%"
+    sampleRate: "%env:SENTRY_SAMPLE_RATE%"
     capture:
       excludeExceptionTypes: []
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,7 +3,7 @@ Flownative:
     dsn: "%env:SENTRY_DSN%"
     environment: "%env:SENTRY_ENVIRONMENT%"
     release: "%env:SENTRY_RELEASE%"
-    sampleRate: "%env:SENTRY_SAMPLE_RATE%"
+    sampleRate: 1
     capture:
       excludeExceptionTypes: []
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ composer require flownative/sentry
 ## Configuration
 
 You need to at least specify a DSN to be used as a logging target. Apart
-from that, you can configure the Sentry environment and release. All
+from that, you can configure the Sentry environment and release. These
 options can either be set in the Flow settings or, more conveniently, by
 setting the respective environment variables.
 
@@ -38,6 +38,16 @@ Flownative:
     environment: "%env:SENTRY_ENVIRONMENT%"
     release: "%env:SENTRY_RELEASE%"
 ```
+
+The error sample rate of Sentry can be set using
+
+```yaml
+Flownative:
+  Sentry:
+    sampleRate: 1
+```
+
+The default is 1 – 100% percent of all errors are sampled.
 
 Throwables (that includes exceptions and runtime errors) are logged as
 Sentry events. You may specify a list of exceptions which should not be


### PR DESCRIPTION
In our project we just started using Sentry but since we expect fairly high numbers of issues, we'd like to be able to adjust the sampleRate as sampling *all* issues could prove quite costly (literally) to us. From what I can tell these two changed files should already do the job but if there's anything I missed please let me know and I'll be happy to make the suggested changes, too!