### PR TITLE
Sanitize settings properly

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -83,9 +83,9 @@ class SentryClient
 
     public function injectSettings(array $settings): void
     {
-        $this->dsn = $settings['dsn'] ?? '';
-        $this->environment = $settings['environment'] ?? '';
-        $this->release = $settings['release'] ?? '';
+        $this->dsn = $settings['dsn'] ?: '';
+        $this->environment = $settings['environment'] ?: '';
+        $this->release = $settings['release'] ?: '';
         $this->sampleRate = (float)($settings['sampleRate'] ?? 1);
         $this->excludeExceptionTypes = $settings['capture']['excludeExceptionTypes'] ?? [];
     }


### PR DESCRIPTION
In case e.g. `SENTRY_RELEASE` is not set, a type error happens:

```
Cannot assign false to property Flownative\Sentry\SentryClient_Original::$release of type string
```

 This makes sure that any falsy value leads to an empty string.