### PR TITLE
Avoid uninitialized use of stracktrace builder

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -53,7 +53,7 @@ class SentryClient
     protected string $release;
     protected float $sampleRate;
     protected array $excludeExceptionTypes = [];
-    protected StacktraceBuilder $stacktraceBuilder;
+    protected ?StacktraceBuilder $stacktraceBuilder = null;
 
     /**
      * @Flow\Inject
@@ -282,8 +282,12 @@ class SentryClient
         return str_replace(['_', FLOW_PATH_ROOT], '/', $matches[1]);
     }
 
-    private function prepareStacktrace(\Throwable $throwable = null): Stacktrace
+    private function prepareStacktrace(\Throwable $throwable = null): ?Stacktrace
     {
+        if ($this->stacktraceBuilder === null) {
+            return null;
+        }
+
         if ($throwable) {
             $stacktrace = $this->stacktraceBuilder->buildFromException($throwable);
         } else {


### PR DESCRIPTION
Do not try to use the stacktrace builder if it's not set up.

This avoids `Typed property Flownative\Sentry\SentryClient_Original::$stacktraceBuilder must not be accessed before initialization` errors in certain situations.

Simply returning `null` in that case is fine, as the places where the return value is used also accept a `null` value.