### PR TITLE
feat: added Option traces_sample_rate

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -51,6 +51,7 @@ class SentryClient
     protected string $release;
 
     protected float $sampleRate = 1;
+    protected float $tracesSampleRate = 0;
     protected int $errorLevel;
     protected array $excludeExceptionTypes = [];
     protected array $excludeExceptionMessagePatterns = [];
@@ -103,6 +104,7 @@ class SentryClient
         $this->release = $settings['release'] ?: $this->release;
 
         $this->sampleRate = (float)($settings['sampleRate'] ?? 1);
+        $this->tracesSampleRate = (float)($settings['tracesSampleRate'] ?? 0);
         $this->excludeExceptionTypes = $settings['capture']['excludeExceptionTypes'] ?? [];
         $this->excludeExceptionMessagePatterns = $settings['capture']['excludeExceptionMessagePatterns'] ?? [];
         $this->excludeExceptionCodes = $settings['capture']['excludeExceptionCodes'] ?? [];
@@ -129,6 +131,7 @@ class SentryClient
             'environment' => $this->environment,
             'release' => $this->release,
             'sample_rate' => $this->sampleRate,
+            'traces_sample_rate' => $this->tracesSampleRate,
             'ignore_exceptions' => array_keys(array_filter($this->excludeExceptionTypes)),
             'in_app_exclude' => [
                 FLOW_PATH_ROOT . '/Packages/Application/Flownative.Sentry/Classes/',

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,7 @@ Flownative:
     environment: "%env:SENTRY_ENVIRONMENT%"
     release: "%env:SENTRY_RELEASE%"
     sampleRate: 1.0
+    tracesSampleRate: 0
     errorLevel: null
     capture:
       excludeExceptionTypes:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Flownative:
 
 The default is 1 – 100% percent of all errors are sampled.
 
+The traces sample rate for performance monitoring can be set using
+
+```yaml
+Flownative:
+  Sentry:
+    tracesSampleRate: 0.25
+```
+
+The default is 0 – performance tracing is disabled. Set a value between 0 and 1
+to enable tracing (e.g. 0.25 for 25% of transactions).
+
 The PHP error level for errors automatically detected by the Sentry SDK can
 be set using:
 


### PR DESCRIPTION
 feat: Add tracesSampleRate setting for Sentry performance monitoring

  - Add tracesSampleRate property to SentryClient
  - Pass traces_sample_rate to Sentry init
  - Document new setting in README
