### PR TITLE
Add excludeExceptionFilePathPrefixesByErrorLevel option

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -56,6 +56,7 @@ class SentryClient
     protected array $excludeExceptionTypes = [];
     protected array $excludeExceptionMessagePatterns = [];
     protected array $excludeExceptionCodes = [];
+    protected array $excludeExceptionFilePathPrefixesByErrorLevel = [];
     protected ?StacktraceBuilder $stacktraceBuilder = null;
 
     /**
@@ -108,6 +109,7 @@ class SentryClient
         $this->excludeExceptionTypes = $settings['capture']['excludeExceptionTypes'] ?? [];
         $this->excludeExceptionMessagePatterns = $settings['capture']['excludeExceptionMessagePatterns'] ?? [];
         $this->excludeExceptionCodes = $settings['capture']['excludeExceptionCodes'] ?? [];
+        $this->excludeExceptionFilePathPrefixesByErrorLevel = $settings['capture']['excludeExceptionFilePathPrefixesByErrorLevel'] ?? [];
         $this->errorLevel = $settings['errorLevel'] ?? error_reporting();
     }
 
@@ -274,6 +276,10 @@ class SentryClient
             return true;
         }
 
+        if ($this->isExcludedByErrorLevelAndFilePath($throwable)) {
+            return true;
+        }
+
         $message = $throwable->getMessage();
         if (array_reduce(
             $this->excludeExceptionMessagePatterns,
@@ -283,6 +289,26 @@ class SentryClient
             false
         )) {
             return true;
+        }
+
+        return false;
+    }
+
+    private function isExcludedByErrorLevelAndFilePath(Throwable $throwable): bool
+    {
+        $severity = E_ERROR;
+        if ($throwable instanceof \ErrorException) {
+            $severity = $throwable->getSeverity();
+        }
+        if (!isset($this->excludeExceptionFilePathPrefixesByErrorLevel[$severity])) {
+            return false;
+        }
+
+        $filePath = $throwable->getFile();
+        foreach ((array)$this->excludeExceptionFilePathPrefixesByErrorLevel[$severity] as $pathPrefix) {
+            if ($pathPrefix !== '' && str_starts_with($filePath, FLOW_PATH_ROOT . $pathPrefix)) {
+                return true;
+            }
         }
 
         return false;

--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -109,8 +109,12 @@ class SentryClient
         $this->excludeExceptionTypes = $settings['capture']['excludeExceptionTypes'] ?? [];
         $this->excludeExceptionMessagePatterns = $settings['capture']['excludeExceptionMessagePatterns'] ?? [];
         $this->excludeExceptionCodes = $settings['capture']['excludeExceptionCodes'] ?? [];
-        $this->excludeExceptionFilePathPrefixesByErrorLevel = $settings['capture']['excludeExceptionFilePathPrefixesByErrorLevel'] ?? [];
         $this->errorLevel = $settings['errorLevel'] ?? error_reporting();
+
+        foreach ($settings['capture']['excludeExceptionFilePathPrefixesByErrorLevel'] ?? [] as $levelMask => $pathPrefixes) {
+            $mask = $this->resolveErrorLevelMask($levelMask);
+            $this->excludeExceptionFilePathPrefixesByErrorLevel[$mask] = $pathPrefixes;
+        }
     }
 
     public function initializeObject(): void
@@ -305,13 +309,30 @@ class SentryClient
         }
 
         $filePath = $throwable->getFile();
-        foreach ((array)$this->excludeExceptionFilePathPrefixesByErrorLevel[$severity] as $pathPrefix) {
-            if ($pathPrefix !== '' && str_starts_with($filePath, FLOW_PATH_ROOT . $pathPrefix)) {
-                return true;
+        foreach ($this->excludeExceptionFilePathPrefixesByErrorLevel as $errorLevelMask => $pathPrefixes) {
+            if (($severity & $errorLevelMask) === 0) {
+                continue;
+            }
+            foreach ((array)$pathPrefixes as $pathPrefix) {
+                if ($pathPrefix !== '' && str_starts_with($filePath, FLOW_PATH_ROOT . $pathPrefix)) {
+                    return true;
+                }
             }
         }
 
         return false;
+    }
+
+    private function resolveErrorLevelMask(string $config): int
+    {
+        $mask = 0;
+        foreach (explode('|', $config) as $constantName) {
+            $constantName = trim($constantName);
+            if (defined($constantName)) {
+                $mask |= constant($constantName);
+            }
+        }
+        return $mask;
     }
 
     private function configureScope(array $extraData, array $tags): void

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -15,6 +15,7 @@ Flownative:
         'Neos\Flow\Property\Exception\TargetNotFoundException': true
       excludeExceptionMessagePatterns: []
       excludeExceptionCodes: []
+      excludeExceptionFilePathPrefixesByErrorLevel: []
 
 Neos:
   Flow:

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Flownative:
       excludeExceptionCodes:
           - 1391972021
       excludeExceptionFilePathPrefixesByErrorLevel:
-        '%E_WARNING%':
-          - '/Packages/Libraries/'
+        'E_WARNING | E_DEPRECATED | E_USER_DEPRECATED':
+          - 'Packages/Libraries/'
 ```
 
 By default all Flow exceptions with a status code of 404 are ignored. In case

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ The default is `null`, that makes Sentry use the value returned by the
 **Beware:** a low error log level can lead to your application not loading
 anymore and your Sentry account being flooded with error messages.
 
-Throwables (that includes exceptions and runtime errors) are logged as
-Sentry events. You may specify a list of exception types, exception message
-regular expressions or exception codes  which should not be which should not be
-recorded.
+Throwables (that include exceptions and runtime errors) are logged as Sentry events.
+You may configure some exclusions that should not be recorded:
+- Exception types
+- Exception message regular expressions
+- Exception codes
+- Exception file path prefixes (relative to the `FLOW_PATH_ROOT`) by error level
 
 ```yaml
 Flownative:
@@ -100,6 +102,9 @@ Flownative:
           - '/^Warning: fopen\(.*/'
       excludeExceptionCodes:
           - 1391972021
+      excludeExceptionFilePathPrefixesByErrorLevel:
+        '%E_WARNING%':
+          - '/Packages/Libraries/'
 ```
 
 By default all Flow exceptions with a status code of 404 are ignored. In case


### PR DESCRIPTION
for more granular control over which exceptions to exclude.

We would like to exclude all 'Warnings' from third party packages.
This is an idea to enable that, with a configuration option like this:
```yaml
Flownative:
  Sentry:
    capture:
      excludeExceptionFilePathPrefixesByErrorLevel:
        'E_WARNING | E_DEPRECATED | E_USER_DEPRECATED':
          - 'Packages/Libraries/'
```