### PR TITLE
fix: bind UserContextServiceInterface instead of UserContextInterface in Objects.yaml

### DIFF
--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,3 @@
-Flownative\Sentry\Context\UserContextInterface:
+Flownative\Sentry\Context\UserContextServiceInterface:
   scope: singleton
   className: Flownative\Sentry\Context\DefaultUserContextService


### PR DESCRIPTION
`DefaultUserContextService` implements `UserContextServiceInterface`, which is also the interface `SentryClient` injects. The previous `Objects.yaml` binding targeted the `UserContext` value-object interface — which `DefaultUserContextService` does not implement — and only worked because Flow's implicit single-implementation resolution happened to pick the right class for the injected interface.

One-line fix, no behavior change; it just makes the intended binding explicit.
