### PR TITLE
fix: apply per-event data via capture-local scope instead of mutating the global scope

### DIFF
--- a/Classes/SentryClient.php
+++ b/Classes/SentryClient.php
@@ -173,15 +173,9 @@ class SentryClient
             $flowVersion = FLOW_VERSION_BRANCH;
         }
 
-        $currentSession = $this->sessionManager?->getCurrentSession();
-
-        SentrySdk::getCurrentHub()->configureScope(static function (Scope $scope) use ($flowVersion, $currentSession): void {
+        SentrySdk::getCurrentHub()->configureScope(static function (Scope $scope) use ($flowVersion): void {
             $scope->setTag('flow_version', $flowVersion);
             $scope->setTag('flow_context', (string)Bootstrap::$staticObjectManager->get(Environment::class)->getContext());
-
-            if ($currentSession instanceof Session && $currentSession->isStarted()) {
-                $scope->setTag('flow_session_sha1', sha1($currentSession->getId()));
-            }
         });
     }
 
@@ -226,11 +220,14 @@ class SentryClient
 
         $tags['exception_code'] = (string)$throwable->getCode();
 
-        $this->setTags();
-        $this->configureScope($extraData, $tags);
         $event = Event::createEvent();
         $this->addThrowableToEvent($throwable, $event);
-        $sentryEventId = SentrySdk::getCurrentHub()->captureEvent($event);
+
+        $sentryEventId = null;
+        SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($event, $extraData, $tags, &$sentryEventId): void {
+            $this->applyCaptureScope($scope, $extraData, $tags);
+            $sentryEventId = SentrySdk::getCurrentHub()->captureEvent($event);
+        });
 
         return new CaptureResult(
             true,
@@ -249,12 +246,15 @@ class SentryClient
             );
         }
 
-        $this->setTags();
-        $this->configureScope($extraData, $tags);
         $eventHint = EventHint::fromArray([
             'stacktrace' => $this->prepareStacktrace(null)
         ]);
-        $sentryEventId = SentrySdk::getCurrentHub()->captureMessage($message, $severity, $eventHint);
+
+        $sentryEventId = null;
+        SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($message, $severity, $eventHint, $extraData, $tags, &$sentryEventId): void {
+            $this->applyCaptureScope($scope, $extraData, $tags);
+            $sentryEventId = SentrySdk::getCurrentHub()->captureMessage($message, $severity, $eventHint);
+        });
 
         return new CaptureResult(
             true,
@@ -288,7 +288,12 @@ class SentryClient
         return false;
     }
 
-    private function configureScope(array $extraData, array $tags): void
+    /**
+     * Applies per-event data to a capture-local scope. Called inside withScope()
+     * so that nothing of this leaks into subsequent events of the same process
+     * (long-running CLI workers would otherwise accumulate stale data).
+     */
+    private function applyCaptureScope(Scope $scope, array $extraData, array $tags): void
     {
         $securityContext = Bootstrap::$staticObjectManager->get(SecurityContext::class);
         if ($securityContext instanceof SecurityContext && $securityContext->isInitialized()) {
@@ -297,15 +302,19 @@ class SentryClient
             $userContext = new UserContext();
         }
 
-        SentrySdk::getCurrentHub()->configureScope(static function (Scope $scope) use ($userContext, $extraData, $tags): void {
-            foreach ($extraData as $extraDataKey => $extraDataValue) {
-                $scope->setExtra($extraDataKey, $extraDataValue);
-            }
-            foreach ($tags as $tagKey => $tagValue) {
-                $scope->setTag($tagKey, $tagValue);
-            }
-            $scope->setUser($userContext->toArray());
-        });
+        foreach ($extraData as $extraDataKey => $extraDataValue) {
+            $scope->setExtra($extraDataKey, $extraDataValue);
+        }
+        foreach ($tags as $tagKey => $tagValue) {
+            $scope->setTag($tagKey, $tagValue);
+        }
+
+        $currentSession = $this->sessionManager?->getCurrentSession();
+        if ($currentSession instanceof Session && $currentSession->isStarted()) {
+            $scope->setTag('flow_session_sha1', sha1($currentSession->getId()));
+        }
+
+        $scope->setUser($userContext->toArray());
     }
 
     private function renderCleanPathAndFilename(string $rawPathAndFilename): string


### PR DESCRIPTION
`captureThrowable()` and `captureMessage()` currently write per-event data (extras, tags, user, the session tag) into the hub's scope permanently via `configureScope()`. In long-running CLI processes — queue workers in particular — data from one capture leaks into all subsequent events of the same process: stale Reference Codes, `exception_code` tags and `WithExtraDataInterface` payloads then decorate unrelated events, which actively misleads debugging.

This applies per-event data inside `withScope()` instead, so it evaporates after each capture. The process-stable `flow_version`/`flow_context` tags remain on the global scope (set at initialization) and are additionally re-applied on the capture-local scope, preserving the previous behavior even when foreign code replaces or clears the hub scope.

Draft while #52 is under discussion — no code dependency on it (applies cleanly to main), but review feedback there may affect naming here.
